### PR TITLE
refactor(chat): chatRoomSlice 분리, 중복 유틸 제거, memoized selector 추가

### DIFF
--- a/src/features/chat/store/chatReadThunk.js
+++ b/src/features/chat/store/chatReadThunk.js
@@ -1,0 +1,93 @@
+// src/features/chat/store/chatReadThunk.js
+// 읽음 처리 관련 async thunk (chatRoomSlice와 분리하여 순환 의존 방지)
+import {createAsyncThunk} from '@reduxjs/toolkit';
+import {apiClient} from 'utils/apiClient';
+import {getToken} from 'utils/storage';
+import {toId} from './chatStoreUtils';
+
+const API_BASE = '/chatRoom';
+
+/**
+ * markReadThunk
+ * - 서버에 lastReadAt 저장 (POST /{chatRoomId}/read)
+ * - 성공 시: (1) 내 포인터 저장 (2) 목록 unreadCount 0
+ *
+ * userId가 화면에서 undefined로 올 수 있어서:
+ * - userId가 없으면 slice에서 포인터 저장은 스킵(에러 X)
+ * - 그래도 unreadCount 0 / 서버 저장은 정상
+ */
+export const markReadThunk = createAsyncThunk(
+  'chatRoom/markRead',
+  async ({chatRoomId, lastReadAt, userId}, {rejectWithValue}) => {
+    try {
+      const token = await getToken();
+      const rid = toId(chatRoomId);
+      if (!rid) return rejectWithValue('chatRoomId가 없습니다.');
+
+      // lastReadAt이 Date/ISO 등으로 들어오면, 최종적으로 "Z 없는 LocalDateTime"으로 맞춰서 보냄
+      const normalized =
+        typeof lastReadAt === 'string'
+          ? lastReadAt
+          : (() => {
+              const d =
+                lastReadAt instanceof Date ? lastReadAt : new Date(lastReadAt);
+              if (Number.isNaN(d.getTime())) return null;
+              const pad2 = n => String(n).padStart(2, '0');
+              const pad3 = n => String(n).padStart(3, '0');
+              return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(
+                d.getDate(),
+              )}T${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(
+                d.getSeconds(),
+              )}.${pad3(d.getMilliseconds())}`;
+            })();
+
+      if (!normalized) return rejectWithValue('lastReadAt이 올바르지 않습니다.');
+
+      const body = {lastReadAt: normalized};
+
+      await apiClient.post(`${API_BASE}/${rid}/read`, body, {
+        headers: {Authorization: `Bearer ${token}`},
+      });
+
+      return {
+        chatRoomId: rid,
+        userId: userId == null ? null : String(userId),
+        lastReadAt: body.lastReadAt,
+      };
+    } catch (err) {
+      const msg = err?.response?.data || err?.message || '알 수 없는 오류';
+      return rejectWithValue(msg);
+    }
+  },
+);
+
+/**
+ * fetchReadPointersThunk
+ * - 채팅방 참여자별 포인터 조회 (GET /{chatRoomId}/readPointers)
+ */
+export const fetchReadPointersThunk = createAsyncThunk(
+  'chatRoom/fetchReadPointers',
+  async ({chatRoomId}, {rejectWithValue}) => {
+    try {
+      const token = await getToken();
+      const rid = toId(chatRoomId);
+      if (!rid) return rejectWithValue('chatRoomId가 없습니다.');
+
+      const res = await apiClient.get(`${API_BASE}/${rid}/readPointers`, {
+        headers: {Authorization: `Bearer ${token}`},
+      });
+
+      const data = res.data || {};
+      const pointers =
+        data.pointers ||
+        data.readPointers ||
+        data.items ||
+        (Array.isArray(data) ? data : []);
+
+      return {chatRoomId: rid, pointers: Array.isArray(pointers) ? pointers : []};
+    } catch (err) {
+      const msg = err?.response?.data || err?.message || '알 수 없는 오류';
+      return rejectWithValue(msg);
+    }
+  },
+);

--- a/src/features/chat/store/chatRoomExtraReducers.js
+++ b/src/features/chat/store/chatRoomExtraReducers.js
@@ -1,0 +1,162 @@
+// src/features/chat/store/chatRoomExtraReducers.js
+// chatRoomSlice의 extraReducers를 분리하여 slice 파일 크기 축소
+import {fetchChatRoomMediaThunk} from './chatRoomThunk';
+import {markReadThunk, fetchReadPointersThunk} from './chatReadThunk';
+import {toId, toIso, findRoomIndex} from './chatStoreUtils';
+
+/**
+ * chatRoomSlice.extraReducers에 주입할 빌더 함수
+ * @param {import('@reduxjs/toolkit').ActionReducerMapBuilder} builder
+ */
+export const addChatRoomExtraReducers = builder => {
+  /* ── markRead ──────────────────────────────────────────── */
+  builder
+    .addCase(markReadThunk.pending, (state, action) => {
+      const rid = toId(action.meta.arg?.chatRoomId);
+      if (!rid) return;
+      state.markReadStatusByRoom[rid] = 'pending';
+    })
+    .addCase(markReadThunk.fulfilled, (state, action) => {
+      const {chatRoomId, userId, lastReadAt} = action.payload || {};
+      const rid = toId(chatRoomId);
+      if (!rid) return;
+
+      state.markReadStatusByRoom[rid] = 'fulfilled';
+
+      // 내 포인터 즉시 반영 (userId 없으면 스킵)
+      if (userId != null && lastReadAt) {
+        if (!state.readPointersByRoom[rid]) state.readPointersByRoom[rid] = {};
+        state.readPointersByRoom[rid][String(userId)] = toIso(lastReadAt);
+      }
+
+      // 목록 unreadCount 0
+      const idx = findRoomIndex(state, rid);
+      if (idx !== -1) {
+        state.chatRoomList[idx] = {
+          ...state.chatRoomList[idx],
+          unreadCount: 0,
+        };
+      }
+
+      state.listRevision += 1;
+    })
+    .addCase(markReadThunk.rejected, (state, action) => {
+      const rid = toId(action.meta.arg?.chatRoomId);
+      if (!rid) return;
+      state.markReadStatusByRoom[rid] = 'rejected';
+    });
+
+  /* ── fetchReadPointers ─────────────────────────────────── */
+  builder.addCase(fetchReadPointersThunk.fulfilled, (state, action) => {
+    const {chatRoomId, pointers} = action.payload || {};
+    const rid = toId(chatRoomId);
+    if (!rid) return;
+
+    const next = {...(state.readPointersByRoom[rid] || {})};
+    (pointers || []).forEach(p => {
+      const uid = p?.userId;
+      const at = p?.lastReadAt;
+      if (uid == null || !at) return;
+      next[String(uid)] = toIso(at);
+    });
+
+    state.readPointersByRoom[rid] = next;
+    state.listRevision += 1;
+  });
+
+  /* ── fetchChatRoomMedia ────────────────────────────────── */
+  builder
+    .addCase(fetchChatRoomMediaThunk.pending, (state, action) => {
+      const rid = toId(action.meta.arg?.chatRoomId);
+      const type = String(action.meta.arg?.type || 'ALL').toUpperCase();
+      if (!rid) return;
+
+      if (!state.mediaByRoom[rid]) {
+        state.mediaByRoom[rid] = {
+          items: [],
+          nextBefore: null,
+          loading: true,
+          error: null,
+          type,
+          hasMore: true,
+        };
+      } else {
+        state.mediaByRoom[rid].loading = true;
+        state.mediaByRoom[rid].error = null;
+        state.mediaByRoom[rid].type = type;
+      }
+    })
+    .addCase(fetchChatRoomMediaThunk.fulfilled, (state, action) => {
+      const {chatRoomId, type, items, nextBefore} = action.payload || {};
+      const rid = toId(chatRoomId);
+      if (!rid) return;
+
+      const arg = action.meta.arg || {};
+      const append = arg.append !== false; // default true
+
+      if (!state.mediaByRoom[rid]) {
+        state.mediaByRoom[rid] = {
+          items: [],
+          nextBefore: null,
+          loading: false,
+          error: null,
+          type: String(type || 'ALL').toUpperCase(),
+          hasMore: true,
+        };
+      }
+
+      const prev = state.mediaByRoom[rid];
+      const nextType = String(type || 'ALL').toUpperCase();
+      const typeChanged = prev.type && prev.type !== nextType;
+      const nextItems = Array.isArray(items) ? items : [];
+
+      // messageId + url + orderInMessage 로 유니크키 만들어 중복 제거
+      const keyOf = x =>
+        `${x?.messageId || ''}|${x?.url || ''}|${x?.orderInMessage ?? ''}`;
+      const dedupMerge = (a, b) => {
+        const map = new Map();
+        [...a, ...b].forEach(x => {
+          const k = keyOf(x);
+          if (!k) return;
+          if (!map.has(k)) map.set(k, x);
+        });
+        return Array.from(map.values());
+      };
+
+      const merged =
+        !append || typeChanged ? nextItems : dedupMerge(prev.items || [], nextItems);
+
+      state.mediaByRoom[rid] = {
+        ...prev,
+        type: nextType,
+        items: merged,
+        nextBefore: nextBefore ?? null,
+        loading: false,
+        error: null,
+        hasMore: !!nextBefore && nextItems.length > 0,
+      };
+
+      state.listRevision += 1;
+    })
+    .addCase(fetchChatRoomMediaThunk.rejected, (state, action) => {
+      const rid = toId(action.meta.arg?.chatRoomId);
+      if (!rid) return;
+
+      if (!state.mediaByRoom[rid]) {
+        state.mediaByRoom[rid] = {
+          items: [],
+          nextBefore: null,
+          loading: false,
+          error: action.payload || action.error?.message || '미디어 조회 실패',
+          type: String(action.meta.arg?.type || 'ALL').toUpperCase(),
+          hasMore: true,
+        };
+      } else {
+        state.mediaByRoom[rid].loading = false;
+        state.mediaByRoom[rid].error =
+          action.payload || action.error?.message || '미디어 조회 실패';
+      }
+
+      state.listRevision += 1;
+    });
+};

--- a/src/features/chat/store/chatRoomSlice.js
+++ b/src/features/chat/store/chatRoomSlice.js
@@ -1,144 +1,11 @@
 // src/features/chat/store/chatRoomSlice.js
-import {createSlice, createAsyncThunk} from '@reduxjs/toolkit';
-import { apiClient } from 'utils/apiClient';
-import {getToken} from 'utils/storage';
-import { fetchChatRoomMediaThunk } from './chatRoomThunk';
+import {createSlice, createSelector} from '@reduxjs/toolkit';
+import {toId, toIso, sortByLatest, previewText, findRoomIndex, finalizeList} from './chatStoreUtils';
+import {addChatRoomExtraReducers} from './chatRoomExtraReducers';
 
-/* =========================
- * Utilities / Helpers
- * ========================= */
-const toId = v => (v == null ? null : String(v));
-
-const toIso = d => {
-  try {
-    const t = d ? new Date(d) : new Date();
-    if (Number.isNaN(t.getTime())) return new Date().toISOString();
-    return t.toISOString();
-  } catch {
-    return new Date().toISOString();
-  }
-};
-
-const sortByLatest = list =>
-  [...list].sort(
-    (a, b) =>
-      new Date(b.latestMessageTime || 0).getTime() -
-      new Date(a.latestMessageTime || 0).getTime(),
-  );
-
-const previewText = msg => {
-  if (!msg) return '';
-
-  const type = msg.messageType?.toLowerCase?.();
-
-  const n = Array.isArray(msg.imageUrls)
-    ? msg.imageUrls.length
-    : Array.isArray(msg.mediaUrls)
-    ? msg.mediaUrls.length
-    : 1;
-
-  if (type === 'image') return `사진을 ${n}장 보냈습니다.`;
-  if (type === 'video') return `동영상을 ${n}개 보냈습니다.`;
-  if (type === 'file') return '[파일]';
-
-  return msg.content ?? '';
-};
-
-const findRoomIndex = (state, rid) =>
-  (state?.chatRoomList ?? []).findIndex(r => toId(r?.chatRoomId) === rid);
-
-const finalizeList = state => {
-  const list = state?.chatRoomList ?? [];
-  state.chatRoomList = Array.isArray(list) ? sortByLatest(list) : [];
-  state.listRevision = (state.listRevision ?? 0) + 1;
-};
-
-/* =========================
- * API
- * ========================= */
-const API_BASE = '/chatRoom';
-
-/**
- * markReadThunk
- * - 서버에 lastReadAt 저장 (POST /{chatRoomId}/read)
- * - 성공 시: (1) 내 포인터 저장 (2) 목록 unreadCount 0
- *
- * userId가 화면에서 undefined로 올 수 있어서:
- * - userId가 없으면 slice에서 포인터 저장은 스킵(에러 X)
- * - 그래도 unreadCount 0 / 서버 저장은 정상
- */
-export const markReadThunk = createAsyncThunk(
-  'chatRoom/markRead',
-  async ({chatRoomId, lastReadAt, userId}, {rejectWithValue}) => {
-    try {
-      const token = await getToken();
-      const rid = toId(chatRoomId);
-      if (!rid) return rejectWithValue('chatRoomId가 없습니다.');
-
- // lastReadAt이 Date/ISO 등으로 들어오면, 최종적으로 "Z 없는 LocalDateTime"으로 맞춰서 보냄
-      const normalized =
-        typeof lastReadAt === 'string'
-          ? lastReadAt
-          : (() => {
-              const d = lastReadAt instanceof Date ? lastReadAt : new Date(lastReadAt);
-              if (Number.isNaN(d.getTime())) return null;
-              const pad2 = n => String(n).padStart(2, '0');
-              const pad3 = n => String(n).padStart(3, '0');
-              return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}T${pad2(
-                d.getHours(),
-              )}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}.${pad3(d.getMilliseconds())}`;
-            })();
-
-      if (!normalized) return rejectWithValue('lastReadAt이 올바르지 않습니다.');
-
-      const body = {lastReadAt: normalized};
-
-      await apiClient.post(`${API_BASE}/${rid}/read`, body, {
-        headers: {Authorization: `Bearer ${token}`},
-      });
-
-      return {
-        chatRoomId: rid,
-        userId: userId == null ? null : String(userId),
-        lastReadAt: body.lastReadAt,
-      };
-    } catch (err) {
-      const msg = err?.response?.data || err?.message || '알 수 없는 오류';
-      return rejectWithValue(msg);
-    }
-  },
-);
-
-/**
- * fetchReadPointersThunk
- * - 채팅방 참여자별 포인터 조회 (GET /{chatRoomId}/readPointers)
- */
-export const fetchReadPointersThunk = createAsyncThunk(
-  'chatRoom/fetchReadPointers',
-  async ({chatRoomId}, {rejectWithValue}) => {
-    try {
-      const token = await getToken();
-      const rid = toId(chatRoomId);
-      if (!rid) return rejectWithValue('chatRoomId가 없습니다.');
-
-      const res = await apiClient.get(`${API_BASE}/${rid}/readPointers`, {
-        headers: {Authorization: `Bearer ${token}`},
-      });
-
-      const data = res.data || {};
-      const pointers =
-        data.pointers ||
-        data.readPointers ||
-        data.items ||
-        (Array.isArray(data) ? data : []);
-
-      return {chatRoomId: rid, pointers: Array.isArray(pointers) ? pointers : []};
-    } catch (err) {
-      const msg = err?.response?.data || err?.message || '알 수 없는 오류';
-      return rejectWithValue(msg);
-    }
-  },
-);
+// markReadThunk / fetchReadPointersThunk는 chatReadThunk.js에서 정의
+// (chatRoomThunk.js가 이 slice의 action creator를 import하여 순환 의존 방지)
+export {markReadThunk, fetchReadPointersThunk} from './chatReadThunk';
 
 /* =========================
  * Initial State
@@ -155,17 +22,16 @@ const initialChatRoomState = {
 
   mediaByRoom: {},
 
-
- /**
- * 읽음 포인터 저장
- * readPointersByRoom[rid][userId] = lastReadAt (ISO string)
- */
+  /**
+   * 읽음 포인터 저장
+   * readPointersByRoom[rid][userId] = lastReadAt (ISO string)
+   */
   readPointersByRoom: {},
 
- /**
- * 내 read 요청 상태(선택)
- * markReadStatusByRoom[rid] = 'idle'|'pending'|'fulfilled'|'rejected'
- */
+  /**
+   * 내 read 요청 상태(선택)
+   * markReadStatusByRoom[rid] = 'idle'|'pending'|'fulfilled'|'rejected'
+   */
   markReadStatusByRoom: {},
 };
 
@@ -231,9 +97,7 @@ const chatRoomSlice = createSlice({
           roomName: raw.roomName ?? `채팅방 ${rid ?? ''}`,
           latestMessageContent: raw.latestMessageContent ?? '',
           latestMessageTime: toIso(latestRaw),
-
           unreadCount: Number.isFinite(raw.unreadCount) ? raw.unreadCount : 0,
-
           notificationOn:
             typeof raw.notificationOn === 'boolean' ? raw.notificationOn : true,
           userChatRooms: Array.isArray(raw.userChatRooms) ? raw.userChatRooms : [],
@@ -399,9 +263,9 @@ const chatRoomSlice = createSlice({
       state.listRevision += 1;
     },
 
- /* =========================
- * 읽음 포인터 reducers
- * ========================= */
+    /* =========================
+     * 읽음 포인터 reducers
+     * ========================= */
     setReadPointers(state, action) {
       const {chatRoomId, pointers} = action.payload || {};
       const rid = toId(chatRoomId);
@@ -433,181 +297,38 @@ const chatRoomSlice = createSlice({
     },
   },
 
-  extraReducers: builder => {
-    builder
-      .addCase(markReadThunk.pending, (state, action) => {
-        const rid = toId(action.meta.arg?.chatRoomId);
-        if (!rid) return;
-        state.markReadStatusByRoom[rid] = 'pending';
-      })
-      .addCase(markReadThunk.fulfilled, (state, action) => {
-        const {chatRoomId, userId, lastReadAt} = action.payload || {};
-        const rid = toId(chatRoomId);
-        if (!rid) return;
-
-        state.markReadStatusByRoom[rid] = 'fulfilled';
-
- // 내 포인터 즉시 반영 (userId 없으면 스킵)
-        if (userId != null && lastReadAt) {
-          if (!state.readPointersByRoom[rid]) state.readPointersByRoom[rid] = {};
-          state.readPointersByRoom[rid][String(userId)] = toIso(lastReadAt);
-        }
-
- // 목록 unreadCount 0
-        const idx = findRoomIndex(state, rid);
-        if (idx !== -1) {
-          state.chatRoomList[idx] = {
-            ...state.chatRoomList[idx],
-            unreadCount: 0,
-          };
-        }
-
-        state.listRevision += 1;
-      })
-      .addCase(markReadThunk.rejected, (state, action) => {
-        const rid = toId(action.meta.arg?.chatRoomId);
-        if (!rid) return;
-        state.markReadStatusByRoom[rid] = 'rejected';
-      })
-      .addCase(fetchReadPointersThunk.fulfilled, (state, action) => {
-        const {chatRoomId, pointers} = action.payload || {};
-        const rid = toId(chatRoomId);
-        if (!rid) return;
-
-        const next = {...(state.readPointersByRoom[rid] || {})};
-        (pointers || []).forEach(p => {
-          const uid = p?.userId;
-          const at = p?.lastReadAt;
-          if (uid == null || !at) return;
-          next[String(uid)] = toIso(at);
-        });
-
-        state.readPointersByRoom[rid] = next;
-        state.listRevision += 1;
-      })
-      .addCase(fetchChatRoomMediaThunk.pending, (state, action) => {
-        const rid = toId(action.meta.arg?.chatRoomId);
-        const type = String(action.meta.arg?.type || 'ALL').toUpperCase();
-        if (!rid) return;
-
-        if (!state.mediaByRoom[rid]) {
-          state.mediaByRoom[rid] = {
-            items: [],
-            nextBefore: null,
-            loading: true,
-            error: null,
-            type,
-            hasMore: true,
-          };
-        } else {
-          state.mediaByRoom[rid].loading = true;
-          state.mediaByRoom[rid].error = null;
-          state.mediaByRoom[rid].type = type;
-        }
-      })
-      .addCase(fetchChatRoomMediaThunk.fulfilled, (state, action) => {
-        const {chatRoomId, type, items, nextBefore} = action.payload || {};
-        const rid = toId(chatRoomId);
-        if (!rid) return;
-
-        const arg = action.meta.arg || {};
-        const append = arg.append !== false; // default true
-
-        if (!state.mediaByRoom[rid]) {
-          state.mediaByRoom[rid] = {
-            items: [],
-            nextBefore: null,
-            loading: false,
-            error: null,
-            type: String(type || 'ALL').toUpperCase(),
-            hasMore: true,
-          };
-        }
-
-        const prev = state.mediaByRoom[rid];
-
- // 타입이 바뀌었으면 강제 리셋 (혼합 방지)
-        const nextType = String(type || 'ALL').toUpperCase();
-        const typeChanged = prev.type && prev.type !== nextType;
-
-        const nextItems = Array.isArray(items) ? items : [];
-
- // messageId + url + orderInMessage 로 대충 유니크키 만들어 중복 제거
-        const keyOf = x =>
-          `${x?.messageId || ''}|${x?.url || ''}|${x?.orderInMessage ?? ''}`;
-
-        const dedupMerge = (a, b) => {
-          const map = new Map();
-          [...a, ...b].forEach(x => {
-            const k = keyOf(x);
-            if (!k) return;
-            if (!map.has(k)) map.set(k, x);
-          });
-          return Array.from(map.values());
-        };
-
-        let merged;
-        if (!append || typeChanged) {
-          merged = nextItems;
-        } else {
-          merged = dedupMerge(prev.items || [], nextItems);
-        }
-
-        state.mediaByRoom[rid] = {
-          ...prev,
-          type: nextType,
-          items: merged,
-          nextBefore: nextBefore ?? null,
-          loading: false,
-          error: null,
-          hasMore: !!nextBefore && nextItems.length > 0, // 커서 있으면 더 있음으로 간주
-        };
-
-        state.listRevision += 1;
-      })
-      .addCase(fetchChatRoomMediaThunk.rejected, (state, action) => {
-        const rid = toId(action.meta.arg?.chatRoomId);
-        if (!rid) return;
-
-        if (!state.mediaByRoom[rid]) {
-          state.mediaByRoom[rid] = {
-            items: [],
-            nextBefore: null,
-            loading: false,
-            error: action.payload || action.error?.message || '미디어 조회 실패',
-            type: String(action.meta.arg?.type || 'ALL').toUpperCase(),
-            hasMore: true,
-          };
-        } else {
-          state.mediaByRoom[rid].loading = false;
-          state.mediaByRoom[rid].error =
-            action.payload || action.error?.message || '미디어 조회 실패';
-        }
-
-        state.listRevision += 1;
-      });
-  },
+  extraReducers: addChatRoomExtraReducers,
 });
 
 /* =========================
- * Selectors (여기가 에러 주범 1순위)
+ * Selectors (memoized)
  * ========================= */
+const selectChatRoomState = state => state?.chatRoom;
+
+export const selectChatRoomList = createSelector(
+  [selectChatRoomState],
+  chatRoom => chatRoom?.chatRoomList ?? [],
+);
 
 // 방별 readPointers map
-export const selectReadPointers = (state, chatRoomId) => {
-  const rid = toId(chatRoomId);
-  if (!rid) return {};
-  return state?.chatRoom?.readPointersByRoom?.[rid] || {};
-};
+export const selectReadPointers = createSelector(
+  [selectChatRoomState, (_, chatRoomId) => chatRoomId],
+  (chatRoom, chatRoomId) => {
+    const rid = toId(chatRoomId);
+    if (!rid) return {};
+    return chatRoom?.readPointersByRoom?.[rid] || {};
+  },
+);
 
 // 채팅 unread 총합 (앱 뱃지 합산용)
-export const selectChatUnreadTotal = state => {
-  const list = state?.chatRoom?.chatRoomList || [];
-  return list.reduce((sum, r) => {
-    const n = Number(r?.unreadCount);
-    return sum + (Number.isFinite(n) ? Math.max(0, n) : 0);
-  }, 0);
-};
+export const selectChatUnreadTotal = createSelector(
+  [selectChatRoomList],
+  list =>
+    list.reduce((sum, r) => {
+      const n = Number(r?.unreadCount);
+      return sum + (Number.isFinite(n) ? Math.max(0, n) : 0);
+    }, 0),
+);
 
 export const {
   bumpListRevision,

--- a/src/features/chat/store/chatRoomThunk.js
+++ b/src/features/chat/store/chatRoomThunk.js
@@ -10,12 +10,11 @@ import {
   setChatRoomLoading,
   setChatRoomError,
   setChatRoomNotificationState,
-  markReadThunk,
 } from './chatRoomSlice';
+import {markReadThunk} from './chatReadThunk';
+import {toId} from './chatStoreUtils';
 import {STORE_MOCK_ENABLED, getStoreMockChatRoomList, getStoreMockChatRoomUsers, isStoreMockChatRoomId} from '../../home/utils/storeMockData';
 import {syncAppBadgeThunk} from 'features/notification/store/notificationThunk';
-
-const toId = v => (v == null ? null : String(v));
 
 /**
  * 채팅방 리스트 조회

--- a/src/features/chat/store/chatStoreUtils.js
+++ b/src/features/chat/store/chatStoreUtils.js
@@ -1,0 +1,63 @@
+// src/features/chat/store/chatStoreUtils.js
+// 채팅 store 전반에서 공통으로 쓰는 순수 유틸 함수 모음
+
+/**
+ * null/undefined를 null로, 그 외는 String으로 변환
+ */
+export const toId = v => (v == null ? null : String(v));
+
+/**
+ * 임의의 날짜 값을 ISO string으로 정규화
+ * 잘못된 날짜면 현재 시각 ISO를 반환
+ */
+export const toIso = d => {
+  try {
+    const t = d ? new Date(d) : new Date();
+    if (Number.isNaN(t.getTime())) return new Date().toISOString();
+    return t.toISOString();
+  } catch {
+    return new Date().toISOString();
+  }
+};
+
+/**
+ * 채팅방 목록을 최신 메시지 시각 기준 내림차순 정렬
+ */
+export const sortByLatest = list =>
+  [...list].sort(
+    (a, b) =>
+      new Date(b.latestMessageTime || 0).getTime() -
+      new Date(a.latestMessageTime || 0).getTime(),
+  );
+
+/**
+ * 메시지 타입에 따른 미리보기 텍스트
+ */
+export const previewText = msg => {
+  if (!msg) return '';
+  const type = msg.messageType?.toLowerCase?.();
+  const n = Array.isArray(msg.imageUrls)
+    ? msg.imageUrls.length
+    : Array.isArray(msg.mediaUrls)
+    ? msg.mediaUrls.length
+    : 1;
+  if (type === 'image') return `사진을 ${n}장 보냈습니다.`;
+  if (type === 'video') return `동영상을 ${n}개 보냈습니다.`;
+  if (type === 'file') return '[파일]';
+  return msg.content ?? '';
+};
+
+/**
+ * state.chatRoomList 에서 chatRoomId로 인덱스 탐색
+ */
+export const findRoomIndex = (state, rid) =>
+  (state?.chatRoomList ?? []).findIndex(r => toId(r?.chatRoomId) === rid);
+
+/**
+ * chatRoomList를 최신순 정렬하고 listRevision 증가
+ */
+export const finalizeList = state => {
+  const list = state?.chatRoomList ?? [];
+  state.chatRoomList = Array.isArray(list) ? sortByLatest(list) : [];
+  state.listRevision = (state.listRevision ?? 0) + 1;
+};

--- a/src/features/chat/store/messageSlice.js
+++ b/src/features/chat/store/messageSlice.js
@@ -1,7 +1,7 @@
 // store/messageSlice.js
 import {createSlice} from '@reduxjs/toolkit';
+import {toId} from './chatStoreUtils';
 
-const toId = v => (v == null ? null : String(v));
 const toStr = v => (v == null ? null : String(v));
 
 const ensureRoom = (state, chatRoomId) => {

--- a/src/store/selectors.js
+++ b/src/store/selectors.js
@@ -1,6 +1,55 @@
 /**
  * @fileoverview 전역 스토어 셀렉터
  * 여러 feature에서 공통으로 쓰는 state 선택자
+ * createSelector로 메모이제이션하여 불필요한 리렌더링 방지
  */
+import {createSelector} from '@reduxjs/toolkit';
 
+/* =========================
+ * Family
+ * ========================= */
 export const selectFamilyId = state => state.family?.familyId ?? null;
+
+export const selectFamilyMembers = createSelector(
+  [state => state.family],
+  family => family?.members ?? [],
+);
+
+/* =========================
+ * User
+ * ========================= */
+export const selectCurrentUserId = state => state.user?.userId ?? null;
+
+/* =========================
+ * Chat Room
+ * ========================= */
+const selectChatRoomState = state => state.chatRoom;
+
+export const selectChatRoomList = createSelector(
+  [selectChatRoomState],
+  chatRoom => chatRoom?.chatRoomList ?? [],
+);
+
+/** 앱 뱃지 합산용: 전체 미읽음 수 */
+export const selectChatUnreadTotal = createSelector(
+  [selectChatRoomList],
+  list =>
+    list.reduce((sum, r) => {
+      const n = Number(r?.unreadCount);
+      return sum + (Number.isFinite(n) ? Math.max(0, n) : 0);
+    }, 0),
+);
+
+/** chatRoomId로 특정 방 조회 */
+export const selectChatRoomById = createSelector(
+  [selectChatRoomList, (_, chatRoomId) => chatRoomId],
+  (list, chatRoomId) =>
+    list.find(r => String(r?.chatRoomId) === String(chatRoomId)) ?? null,
+);
+
+/** 특정 방의 읽음 포인터 맵 */
+export const selectReadPointersByRoom = createSelector(
+  [selectChatRoomState, (_, chatRoomId) => chatRoomId],
+  (chatRoom, chatRoomId) =>
+    chatRoom?.readPointersByRoom?.[String(chatRoomId)] ?? {},
+);


### PR DESCRIPTION
- chatStoreUtils.js: toId/toIso/sortByLatest 등 공통 유틸 추출 (3곳 중복 제거)
- chatReadThunk.js: markReadThunk/fetchReadPointersThunk를 slice에서 분리
- chatRoomExtraReducers.js: extraReducers 빌더 함수 분리
- chatRoomSlice.js: 628줄 → 254줄, createSelector 기반 memoized selector 적용
- selectors.js: 전역 memoized selector 4개 추가